### PR TITLE
Added #equals and #hashCode to class Vector3

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>libtrails</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <repositories>
         <repository>

--- a/library/src/main/java/com/devcexx/libtrails/LinearTransf.java
+++ b/library/src/main/java/com/devcexx/libtrails/LinearTransf.java
@@ -16,6 +16,7 @@
 
 package com.devcexx.libtrails;
 
+import java.util.Vector;
 import java.util.function.Function;
 
 public abstract class LinearTransf {
@@ -38,6 +39,18 @@ public abstract class LinearTransf {
     }
 
     public static Function<Vector3, Vector3> rotateRenderPlane(Vector3 normal) {
+        //Gets the rotation axis of the transformation.
+        Vector3 axis = Vector3.AXIS_Y.cross(normal).normalize();
+        if (axis.equals(Vector3.ORIGIN)) {
+            if (Vector3.AXIS_Y.dot(normal) > 0) {
+                //Axis Y has the same direction as normal. Nothing to do
+                return v -> v;
+            } else {
+                //Axis Y is opposite to normal.
+                axis = Vector3.AXIS_Z;
+            }
+        }
+
         //Get normal vector on the XZ plane.
         Vector3 xzvector = normal.stripY();
 
@@ -47,7 +60,6 @@ public abstract class LinearTransf {
                 Vector3.AXIS_Y);
 
         //Gets the rotation axis of the transformation.
-        Vector3 axis = Vector3.AXIS_Y.cross(normal);
         float angle = (float) normal.angle(Vector3.AXIS_Y);
 
         //First rotation: rotates the point around the y axis
@@ -57,6 +69,7 @@ public abstract class LinearTransf {
         //Second rotation: rotates the point around the axis of the
         //rotation between the Y axis and the new normal axis, to place
         //the drawing inside the plane.
-        return v -> v.rotateY(yAngle + (float) Math.PI).rotate(axis, angle);
+        Vector3 faxis = axis;
+        return v -> v.rotateY(yAngle + (float) Math.PI).rotate(faxis, angle);
     }
 }

--- a/library/src/main/java/com/devcexx/libtrails/Vector3.java
+++ b/library/src/main/java/com/devcexx/libtrails/Vector3.java
@@ -427,6 +427,7 @@ public class Vector3 {
      */
     public Vector3 normalize(){
         float mod = (float) this.norm();
+        if (mod == 0) return Vector3.ORIGIN;
         return new Vector3(x / mod, y / mod, z / mod);
     }
 
@@ -601,6 +602,24 @@ public class Vector3 {
      */
     public Location toLocation(World w, float pitch, float yaw){
         return new Location(w, x, y, z, yaw, pitch);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Vector3 vector3 = (Vector3) o;
+
+        return Float.compare(vector3.x, x) == 0 && Float.compare(vector3.y, y) == 0 && Float.compare(vector3.z, z) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (x != +0.0f ? Float.floatToIntBits(x) : 0);
+        result = 31 * result + (y != +0.0f ? Float.floatToIntBits(y) : 0);
+        result = 31 * result + (z != +0.0f ? Float.floatToIntBits(z) : 0);
+        return result;
     }
 
     @Override


### PR DESCRIPTION
Fixed a problem that makes the method #normalize from Vector3 to return [NaN, NaN, NaN] when it's called from a vector with norm 0
Now the transformation rotateRenderPlane handles correctly the cases where the normal input vector has the same direction, of vector (0, 1, 0)